### PR TITLE
Adding networks specs in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     build:
         context: "./frontend/events"
         dockerfile: "./Dockerfile"
-  networks:
-    - events_net
+    networks:
+      - events_net
   backend:
     build:
       context: "./backend"
@@ -28,3 +28,7 @@ services:
       - 80:80
     networks:
       - events_net
+      
+  
+  networks:
+    events_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,20 @@ services:
     build:
         context: "./frontend/events"
         dockerfile: "./Dockerfile"
+  networks:
+    - events_net
   backend:
     build:
       context: "./backend"
       dockerfile: "./Dockerfile"
+    networks:
+      - events_net
   db:
     image: mongo:latest
     ports:
       - 27017:27017
+    networks:
+      - events_net
   proxy:
     image: nginx:stable-alpine
     environment:
@@ -20,3 +26,5 @@ services:
       - ${PWD}/nginx.conf:/etc/nginx/templates/nginx.conf.conf
     ports:
       - 80:80
+    networks:
+      - events_net


### PR DESCRIPTION
This PR adds an events_net network so as to avoid the risk of breaking the connection from the backend to the database.